### PR TITLE
Fixes broker crash and failed tests under Node 14

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,6 @@ module.exports = function(opts) {
       state = 'starting';
 
       server = http.createServer(handler);
-      server.on('request', handler);
       server.listen(opts.port, err => {
         if (err) {
           return broker.logger.error('Unable to start health-check server', err);


### PR DESCRIPTION
`http.createServer` already adds `handler` to the request-event. This is also the case for older node-versions.
https://nodejs.org/docs/latest-v14.x/api/http.html#http_http_createserver_options_requestlistener

Adding the handler twice under Node 14 leads to an error as the handler is called twice and the request is already closed.
The error is not caught and leads to the termination of the moleculer-broker/node-process if the health-check-route is called.

With this change, all test pass under node 8, 10, 12 and 14.